### PR TITLE
Some small additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ The full table you can pass to the `switcher` function:
   }
 ```
 
-Note: for menu_theme, the options you can change are:
-- height -- of each item
-- width  -- of entire menu
-- [fg_bg]_[normal|focus] -- control colour of focused/other items, bg = background, fg = text
-- border_[color|width] -- control border around whole menu
-- submenu_icon -- path to image file
+Note: for `menu_theme`, the options you can change are:
+- `height` -- of each item
+- `width`  -- of entire menu
+- `[fg_bg]_[normal|focus]` -- control colour of focused/other items, bg = background, fg = text
+- `border_[color|width]` -- control border around whole menu
+- `submenu_icon` -- path to image file
 For any colours, like in awesome itself, the value is a hex string like '#ff00ff' or '00ff00'
 If left alone these will be set matching your theme.
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,48 @@ The full table you can pass to the `switcher` function (some are pretty useless 
 
 ```lua
   {
-    coords = { x = 0, y = 0 },   -- default: the mouse's coordinates
-    hide_notification = false,   -- default: true
-    notification_text = "NOPE",  -- default: "No matches. Resetting"
-    notification_timeout = 5     -- default: 1
+    coords = { x = 0, y = 0 },   -- position of TL corner of menu (default: the mouse's coordinates)
+    hide_notification = false,   -- show the cheeky notification if nothing matches (default: true)
+    notification_text = "NOPE",  -- contents of cheeky notification (default: "No matches. Resetting")
+    notification_timeout = 5     -- time for notifications to remain onscreen (default: 1)
+    menu_theme = {height = 20, width = 400}, -- theme options for menu (default: {height = 15, width = 400})
+    show_tag = true,             -- display tag at left side of menu (default: true)
+    show_screen = true,          -- display screen index at left side of menu (default: false)
+    quit_key = '\',              -- close menu if this key is entered (default: '')
   }
 ```
 
 Type away!
+
+## Further customisations in rc.lua:
+
+```lua
+    awful.key({ modkey,           }, "Tab", function () 
+                                              mouse.screen = client.focus.screen
+                                              -- place the switcher in the centre of the screen with focus
+                                              local x_pos = screen[mouse.screen].geometry.width/2-200+screen[mouse.screen].geometry.x
+                                              local y_pos = screen[mouse.screen].geometry.height/2-200+screen[mouse.screen].geometry.y
+                                              -- move the mouse there as well
+                                              mouse.coords({
+                                                x = x_pos,
+                                                y = y_pos
+                                              })
+                                              cheeky.util.switcher({
+                                                coords = {
+                                                  x = x_pos,
+                                                  y = y_pos
+                                                },
+                                                menu_theme = {
+                                                  height = 15,
+                                                  width = 400
+                                                },
+                                                show_tag = false,
+                                                show_screen = true,
+                                                -- space is literal here for some reason
+                                                -- but it is easier to hit than Escape
+                                                quit_key = ' ', 
+                                              }) end),
+```
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ Type away!
 
 ```lua
     awful.key({ modkey,           }, "Tab", function () 
-                                              mouse.screen = client.focus.screen
-                                              -- place the switcher in the centre of the screen with focus
+                                              -- place the switcher in the centre of the screen with mouse focus
                                               local x_pos = screen[mouse.screen].geometry.width/2-200+screen[mouse.screen].geometry.x
                                               local y_pos = screen[mouse.screen].geometry.height/2-200+screen[mouse.screen].geometry.y
                                               -- move the mouse there as well

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ end),
 
 #### Other options
 
-The full table you can pass to the `switcher` function (some are pretty useless but... meh):
+The full table you can pass to the `switcher` function:
 
 ```lua
   {
@@ -73,6 +73,15 @@ The full table you can pass to the `switcher` function (some are pretty useless 
     quit_key = '\',              -- close menu if this key is entered (default: '')
   }
 ```
+
+Note: for menu_theme, the options you can change are:
+- height -- of each item
+- width  -- of entire menu
+- [fg_bg]_[normal|focus] -- control colour of focused/other items, bg = background, fg = text
+- border_[color|width] -- control border around whole menu
+- submenu_icon -- path to image file
+For any colours, like in awesome itself, the value is a hex string like '#ff00ff' or '00ff00'
+If left alone these will be set matching your theme.
 
 Type away!
 

--- a/util.lua
+++ b/util.lua
@@ -45,7 +45,9 @@ function match_clients(str)
       or awful.rules.match(c, { class = low_str })
 
     then
-      table.insert(clients, { c.name, function()
+      local tag = c.tags(c)[1]
+      local screen = c.screen
+      table.insert(clients, { tag.name .. "(" .. screen .. "): " .. c.name, function()
                                 client.focus = c
                                 c:raise()
                                 awful.client.jumpto(c) end,

--- a/util.lua
+++ b/util.lua
@@ -14,9 +14,13 @@ local client_menu = nil
 
 local options = {
   -- coords are handled by Awesome --
-  hide_notification     = false,
+  hide_notification     = true,
   notification_text     = "No matches. Resetting.",
-  notification_timeout  = 1
+  notification_timeout  = 1,
+  menu_theme            = {height = 25, width = 400},
+  show_tag              = true, -- display tag at left side of menu
+  show_screen           = true, -- display screen index at left side of menu
+  quit_key              = '',   -- close menu if this key is entered
 }
 
 function no_case(str)
@@ -31,7 +35,9 @@ end
 function draw_menu(list)
   if client_menu then client_menu:hide() end
 
-  client_menu = awful.menu(list)
+  client_menu = awful.menu.new({items = list, 
+                            theme = options.menu_theme
+                           })
   client_menu:item_enter(1)
   client_menu:show(options)
 end
@@ -47,7 +53,18 @@ function match_clients(str)
     then
       local tag = c.tags(c)[1]
       local screen = c.screen
-      table.insert(clients, { tag.name .. "(" .. screen .. "): " .. c.name, function()
+      local menu_entry = ""
+
+      if options.show_tag then
+        menu_entry = menu_entry .. "[" .. tag.name .. "] "
+      end
+
+      if options.show_screen then
+        menu_entry = menu_entry .. "<" .. screen .. "> "
+      end
+
+      menu_entry = menu_entry .. c.name
+      table.insert(clients, { menu_entry, function()
                                 client.focus = c
                                 c:raise()
                                 awful.client.jumpto(c) end,
@@ -84,11 +101,12 @@ function append_rerun(key)
 end
 
 function grabber(mod, key, event)
+  --naughty.notify({text = key})
   local sel = client_menu.sel or 0
 
   if event == "release" then return end
 
-  if key == 'Down' then
+  if key == 'Down' or key == 'Tab' then
     local sel_new = (sel + 1) > #client_menu.items and 1 or (sel + 1)
     client_menu:item_enter(sel_new)
 
@@ -117,7 +135,7 @@ function grabber(mod, key, event)
     or key == 'Super_L'
     or key == 'Super_R' then return
 
-  elseif key == 'Escape' then
+  elseif key == 'Escape' or key == options.quit_key then
     close()
 
   elseif key == "BackSpace" then


### PR DESCRIPTION
- [x] Optional menu theming (with sensible default)
- [x] Optionally show tag (default on)
- [x] Optionally show screen index (default off)
- [x] Optionally specify a 'quit key' which will exit the menu (space or '/' work well for this, but defaults to none)
- [x] Scroll through the menu with Tab instead of trying to compare it to clients
- [x] Default hide_notification to true (matching README)
- [x] Extend README to match above changes
- [x] Add further example of configuration to README, showing a means of displaying the switcher on the currently-focused screen

I found this switcher the other day and really like it. I tend to have a bunch of the same window type (like Terminal) though, so I thought tags might be helpful to show. Next thing I knew, it was hours later and I'd made a collection of other changes.