### PR TITLE
Optionally show tag and screen in switcher menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The full table you can pass to the `switcher` function:
     hide_notification = true,    -- hide the cheeky notification if nothing matches (default: false)
     notification_text = "NOPE",  -- contents of cheeky notification (default: "No matches. Resetting")
     notification_timeout = 5,    -- time for notifications to remain onscreen (default: 1)
-    show_tag = true,             -- display tag at left side of menu (default: true)
+    show_tag = true,             -- display tag at left side of menu (default: false)
     show_screen = true,          -- display screen index at left side of menu (default: false)
   }
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A cheeky window switcher for Awesome WM
 
 ## Description
 
-It popus up a menu with all your clients. As you type,
+It pops up a menu with all your clients. As you type, it
 case-insensitively filters the clients that match with the
 name or class.
 
@@ -59,14 +59,16 @@ end),
 
 #### Other options
 
-The full table you can pass to the `switcher` function (some are pretty useless but... meh):
+The full table you can pass to the `switcher` function:
 
 ```lua
   {
-    coords = { x = 0, y = 0 },   -- default: the mouse's coordinates
-    hide_notification = false,   -- default: true
-    notification_text = "NOPE",  -- default: "No matches. Resetting"
-    notification_timeout = 5     -- default: 1
+    coords = { x = 0, y = 0 },   -- position of TL corner of menu (default: the mouse's coordinates)
+    hide_notification = true,    -- show the cheeky notification if nothing matches (default: false)
+    notification_text = "NOPE",  -- contents of cheeky notification (default: "No matches. Resetting")
+    notification_timeout = 5,    -- time for notifications to remain onscreen (default: 1)
+    show_tag = true,             -- display tag at left side of menu (default: true)
+    show_screen = true,          -- display screen index at left side of menu (default: false)
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The full table you can pass to the `switcher` function:
 ```lua
   {
     coords = { x = 0, y = 0 },   -- position of TL corner of menu (default: the mouse's coordinates)
-    hide_notification = true,    -- show the cheeky notification if nothing matches (default: false)
+    hide_notification = true,    -- hide the cheeky notification if nothing matches (default: false)
     notification_text = "NOPE",  -- contents of cheeky notification (default: "No matches. Resetting")
     notification_timeout = 5,    -- time for notifications to remain onscreen (default: 1)
     show_tag = true,             -- display tag at left side of menu (default: true)

--- a/util.lua
+++ b/util.lua
@@ -16,7 +16,9 @@ local options = {
   -- coords are handled by Awesome --
   hide_notification     = false,
   notification_text     = "No matches. Resetting.",
-  notification_timeout  = 1
+  notification_timeout  = 1,
+  show_tag              = false, -- display tag at left side of menu
+  show_screen           = false, -- display screen index at left side of menu
 }
 
 function no_case(str)
@@ -45,7 +47,20 @@ function match_clients(str)
       or awful.rules.match(c, { class = low_str })
 
     then
-      table.insert(clients, { c.name, function()
+      local tag = c.tags(c)[1]
+      local screen = c.screen
+      local menu_entry = ""
+
+      if options.show_tag then
+        menu_entry = menu_entry .. "[" .. tag.name .. "] "
+      end
+
+      if options.show_screen then
+        menu_entry = menu_entry .. "(" .. screen .. ") "
+      end
+
+      menu_entry = menu_entry .. c.name
+      table.insert(clients, { menu_entry, function()
                                 client.focus = c
                                 c:raise()
                                 awful.client.jumpto(c) end,


### PR DESCRIPTION
First of three PRs based on svexican/cheeky#4, breaking it up into more granular chunks.

- [x] Add `show_tag` and `show_screen` options to the switcher function allowing user to enable showing
tag, screen, or both (default: neither)
- [x] Update README to reflect new options
- [x] Small bit of typo correction on the README (`hide_notification` defaults to false, not true)