### PR TITLE
Add menu theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,13 @@ The full table you can pass to the `switcher` function (some are pretty useless 
     hide_notification = false,   -- default: true
     notification_text = "NOPE",  -- default: "No matches. Resetting"
     notification_timeout = 5     -- default: 1
+    menu_theme = {height = 20, width = 400}, -- theme options for menu (default: nil)
   }
 ```
+
+Note: for `menu_theme`, the options you can change are listed in the awesomewm API for awful.menu.new:
+https://awesomewm.org/doc/api/modules/awful.menu.html
+The contents of the `menu_theme` table will only be applied to the cheeky switcher menu, not other menus in awesomewm. If left blank, the cheeky switcher menu will use theme settings defined by your theme.
 
 Type away!
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The full table you can pass to the `switcher` function (some are pretty useless 
     coords = { x = 0, y = 0 },   -- default: the mouse's coordinates
     hide_notification = false,   -- default: true
     notification_text = "NOPE",  -- default: "No matches. Resetting"
-    notification_timeout = 5     -- default: 1
+    notification_timeout = 5,    -- default: 1
     menu_theme = {height = 20, width = 400}, -- theme options for menu (default: nil)
   }
 ```

--- a/util.lua
+++ b/util.lua
@@ -16,7 +16,8 @@ local options = {
   -- coords are handled by Awesome --
   hide_notification     = false,
   notification_text     = "No matches. Resetting.",
-  notification_timeout  = 1
+  notification_timeout  = 1,
+  menu_theme            = {},
 }
 
 function no_case(str)
@@ -31,7 +32,9 @@ end
 function draw_menu(list)
   if client_menu then client_menu:hide() end
 
-  client_menu = awful.menu(list)
+  client_menu = awful.menu.new({items = list, 
+                            theme = options.menu_theme
+                           })
   client_menu:item_enter(1)
   client_menu:show(options)
 end


### PR DESCRIPTION
Second of three PRs based on svexican/cheeky#4, breaking it up into more granular chunks.

- [x] Add `menu_theme` option to change the switcher's appearance based on awesomewm menu theme options
- [x] Explain use of `menu_theme` option in README