### PR TITLE
Add optional alternative quit key

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The full table you can pass to the `switcher` function (some are pretty useless 
     coords = { x = 0, y = 0 },   -- default: the mouse's coordinates
     hide_notification = false,   -- default: true
     notification_text = "NOPE",  -- default: "No matches. Resetting"
-    notification_timeout = 5     -- default: 1
+    notification_timeout = 5,    -- default: 1
     quit_key = '\',              -- close menu if this key is entered (default: nil)
   }
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The full table you can pass to the `switcher` function (some are pretty useless 
     hide_notification = false,   -- default: true
     notification_text = "NOPE",  -- default: "No matches. Resetting"
     notification_timeout = 5     -- default: 1
+    quit_key = '\',              -- close menu if this key is entered (default: nil)
   }
 ```
 

--- a/util.lua
+++ b/util.lua
@@ -17,7 +17,7 @@ local options = {
   hide_notification     = false,
   notification_text     = "No matches. Resetting.",
   notification_timeout  = 1,
-  quit_key              = '',   -- close menu if this key is entered
+  quit_key              = nil,   -- close menu if this key is entered
 }
 
 function no_case(str)

--- a/util.lua
+++ b/util.lua
@@ -16,7 +16,8 @@ local options = {
   -- coords are handled by Awesome --
   hide_notification     = false,
   notification_text     = "No matches. Resetting.",
-  notification_timeout  = 1
+  notification_timeout  = 1,
+  quit_key              = '',   -- close menu if this key is entered
 }
 
 function no_case(str)
@@ -115,7 +116,7 @@ function grabber(mod, key, event)
     or key == 'Super_L'
     or key == 'Super_R' then return
 
-  elseif key == 'Escape' then
+  elseif key == 'Escape' or key == options.quit_key then
     close()
 
   elseif key == "BackSpace" then


### PR DESCRIPTION
Third of three PRs based on svexican/cheeky#4, breaking it up into more granular chunks.

Lets user specify an alternative to Escape that will also close the switcher, in case the Escape key is inconvenient to reach.

- [x] Add `quit_key` option to switcher specifying another key which will quit the switcher (default: nil)
- [x] Update README to reflect this new option

(@svexican I wanted to include the Tab/Shift-Tab behaviour to scroll up and down in this PR, but I could not get Shift-Tab working no matter what I tried, so I left it out. If you have any tips on that front I'd love to hear them. None of the documentation seems to cover detecting a certain modkey in a keygrabber.)