### PR TITLE
Add 'select_key' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The full table you can pass to the `switcher` function:
     show_screen = true,          -- display screen index at left side of menu (default: false)
     menu_theme = {height = 20, width = 400}, -- theme options for menu (default: nil)
     quit_key = '\',              -- close menu if this key is entered (default: nil)
+    select_key = '`',            -- select highlighted option if this key is entered (default: nil)
   }
 ```
 

--- a/util.lua
+++ b/util.lua
@@ -21,6 +21,7 @@ local options = {
   show_tag              = false, -- display tag at left side of menu
   show_screen           = false, -- display screen index at left side of menu
   quit_key              = nil,   -- close menu if this key is entered
+  select_key            = nil,   -- select an option if this key is entered
 }
 
 function no_case(str)
@@ -121,7 +122,7 @@ function grabber(mod, key, event)
     client_menu:exec(10, { exec = true })
     close()
 
-  elseif sel > 0 and key == 'Return' then
+  elseif sel > 0 and (key == 'Return' or key == options.select_key) then
     client_menu:exec(sel, { exec = true })
     close()
 


### PR DESCRIPTION
This might be handy for users who use a lot of mouse-heavy applications (like me with my multiple browsers!). 

Enter/Return is rather far away if operating the menu with only the left hand on the home row, so I had been looking for a way to make that less of a stretch. With the '\`' key directly above Tab on my keyboard, I thought perhaps just specifying that as an alternative select key, similar to my alternative quit key, would solve the problem. (Thinking about it, I may switch them around in my personal configuration, hitting Space is a nicer way to select something, and '\`' would be more useful as a slightly closer replacement for the Escape key.)

- [x] Allow the user to optionally specify a key which, if pressed, will select the currently highlighted option
- [x] Update README to reflect new option